### PR TITLE
fix auto install: avoid db exists error

### DIFF
--- a/xml/auto_install.xml
+++ b/xml/auto_install.xml
@@ -17,26 +17,6 @@
   </CustomGroups>
   <CustomFields>
     <CustomField>
-      <name>Email_Recipient_System</name>
-      <label>Email Recipient System</label>
-      <data_type>String</data_type>
-      <html_type>Select</html_type>
-      <is_required>0</is_required>
-      <is_searchable>0</is_searchable>
-      <is_search_range>0</is_search_range>
-      <weight>1</weight>
-      <help_post>Select a system for sending emails to decision-makers or the press from this petition.</help_post>
-      <is_active>1</is_active>
-      <is_view>0</is_view>
-      <text_length>255</text_length>
-      <note_columns>60</note_columns>
-      <note_rows>4</note_rows>
-      <column_name>email_recipient_system</column_name>
-      <in_selector>0</in_selector>
-      <option_group_name>email_recipient_system</option_group_name>
-      <custom_group_name>Email_Recipient</custom_group_name>
-    </CustomField>
-    <CustomField>
       <name>Recipient_Group</name>
       <label>Recipient Group</label>
       <data_type>String</data_type>

--- a/xml/auto_install.xml
+++ b/xml/auto_install.xml
@@ -20,7 +20,8 @@
       <name>Recipient_Group</name>
       <label>Recipient Group</label>
       <data_type>String</data_type>
-      <html_type>Multi-Select</html_type>
+      <html_type>Select</html_type>
+      <serialize>1</serialize>
       <is_required>0</is_required>
       <is_searchable>0</is_searchable>
       <is_search_range>0</is_search_range>


### PR DESCRIPTION
This field should already be in place via the petitionemail extension.

This is the same fix as discussed in https://github.com/josephlacey/com.jlacey.petitionemailcontactref/issues/1